### PR TITLE
[Issue 515] Update imports from beckn to beckn-one in beckn-onix

### DIFF
--- a/cmd/adapter/main.go
+++ b/cmd/adapter/main.go
@@ -13,10 +13,10 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/beckn/beckn-onix/core/module"
-	"github.com/beckn/beckn-onix/core/module/handler"
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/plugin"
+	"github.com/beckn-one/beckn-onix/core/module"
+	"github.com/beckn-one/beckn-onix/core/module/handler"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/plugin"
 )
 
 // Config struct holds all configurations.

--- a/cmd/adapter/main_test.go
+++ b/cmd/adapter/main_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/beckn/beckn-onix/core/module"
-	"github.com/beckn/beckn-onix/core/module/handler"
-	"github.com/beckn/beckn-onix/pkg/plugin"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/core/module"
+	"github.com/beckn-one/beckn-onix/core/module/handler"
+	"github.com/beckn-one/beckn-onix/pkg/plugin"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/core/module/client/registery.go
+++ b/core/module/client/registery.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/core/module/client/registry_test.go
+++ b/core/module/client/registry_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/stretchr/testify/require"
 )
 

--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
 // PluginManager defines an interface for managing plugins dynamically.

--- a/core/module/handler/stdHandler.go
+++ b/core/module/handler/stdHandler.go
@@ -8,12 +8,12 @@ import (
 	"net/http"
 	"net/http/httputil"
 
-	"github.com/beckn/beckn-onix/core/module/client"
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/response"
+	"github.com/beckn-one/beckn-onix/core/module/client"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/response"
 )
 
 // stdHandler orchestrates the execution of defined processing steps.

--- a/core/module/handler/step.go
+++ b/core/module/handler/step.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
 // signStep represents the signing step in the processing pipeline.

--- a/core/module/module.go
+++ b/core/module/module.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/beckn/beckn-onix/core/module/handler"
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/core/module/handler"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Config represents the configuration for a module.

--- a/core/module/module_test.go
+++ b/core/module/module_test.go
@@ -7,10 +7,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/beckn/beckn-onix/core/module/handler"
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/core/module/handler"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
 // mockPluginManager is a mock implementation of the PluginManager interface

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/beckn/beckn-onix
+module github.com/beckn-one/beckn-onix
 
 go 1.24.0
 
@@ -25,9 +25,9 @@ require github.com/zenazn/pkcs7pad v0.0.0-20170308005700-253a5b1f0e03
 require golang.org/x/text v0.23.0 // indirect
 
 require (
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
@@ -50,9 +50,9 @@ require (
 require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/redis/go-redis/v9 v9.8.0
 	github.com/hashicorp/vault/api v1.16.0
 	github.com/rabbitmq/amqp091-go v1.10.0
+	github.com/redis/go-redis/v9 v9.8.0
 	github.com/rs/zerolog v1.34.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/rs/zerolog"
 	"gopkg.in/natefinch/lumberjack.v2"
 )

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 type ctxKey any

--- a/pkg/plugin/definition/keymanager.go
+++ b/pkg/plugin/definition/keymanager.go
@@ -3,7 +3,7 @@ package definition
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // KeyManager defines the interface for key management operations/methods.

--- a/pkg/plugin/definition/registry.go
+++ b/pkg/plugin/definition/registry.go
@@ -3,7 +3,7 @@ package definition
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 type RegistryLookup interface {

--- a/pkg/plugin/definition/router.go
+++ b/pkg/plugin/definition/router.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // RouterProvider initializes the a new Router instance with the given config.

--- a/pkg/plugin/definition/step.go
+++ b/pkg/plugin/definition/step.go
@@ -3,7 +3,7 @@ package definition
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 type Step interface {

--- a/pkg/plugin/implementation/cache/cache.go
+++ b/pkg/plugin/implementation/cache/cache.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/log"
 	"github.com/redis/go-redis/v9"
 )
 

--- a/pkg/plugin/implementation/cache/cmd/plugin.go
+++ b/pkg/plugin/implementation/cache/cmd/plugin.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/cache"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/cache"
 )
 
 // cacheProvider implements the CacheProvider interface for the cache plugin.

--- a/pkg/plugin/implementation/cache/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/cache/cmd/plugin_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/cache"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/cache"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/pkg/plugin/implementation/decrypter/cmd/plugin.go
+++ b/pkg/plugin/implementation/decrypter/cmd/plugin.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	decrypter "github.com/beckn/beckn-onix/pkg/plugin/implementation/decrypter"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	decrypter "github.com/beckn-one/beckn-onix/pkg/plugin/implementation/decrypter"
 )
 
 // decrypterProvider implements the definition.decrypterProvider interface.

--- a/pkg/plugin/implementation/decrypter/decrypter.go
+++ b/pkg/plugin/implementation/decrypter/decrypter.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/zenazn/pkcs7pad"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // decrypter implements the Decrypter interface and handles the decryption process.

--- a/pkg/plugin/implementation/encrypter/cmd/plugin.go
+++ b/pkg/plugin/implementation/encrypter/cmd/plugin.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/encrypter"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/encrypter"
 )
 
 // encrypterProvider implements the definition.encrypterProvider interface.

--- a/pkg/plugin/implementation/encrypter/encrypter.go
+++ b/pkg/plugin/implementation/encrypter/encrypter.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/zenazn/pkcs7pad"
 )
 

--- a/pkg/plugin/implementation/keymanager/cmd/plugin.go
+++ b/pkg/plugin/implementation/keymanager/cmd/plugin.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/keymanager"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/keymanager"
 )
 
 // keyManagerProvider implements the plugin provider for the KeyManager plugin.

--- a/pkg/plugin/implementation/keymanager/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/keymanager/cmd/plugin_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/keymanager"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/keymanager"
 )
 
 type mockRegistry struct {

--- a/pkg/plugin/implementation/keymanager/keymanager.go
+++ b/pkg/plugin/implementation/keymanager/keymanager.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/google/uuid"
 	vault "github.com/hashicorp/vault/api"
 )

--- a/pkg/plugin/implementation/keymanager/keymanager_test.go
+++ b/pkg/plugin/implementation/keymanager/keymanager_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/google/uuid"
 	"github.com/hashicorp/vault/api"
 	vault "github.com/hashicorp/vault/api"

--- a/pkg/plugin/implementation/publisher/cmd/plugin.go
+++ b/pkg/plugin/implementation/publisher/cmd/plugin.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/publisher"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/publisher"
 )
 
 // publisherProvider implements the PublisherProvider interface.

--- a/pkg/plugin/implementation/publisher/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/publisher/cmd/plugin_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/publisher"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/publisher"
 	"github.com/rabbitmq/amqp091-go"
 )
 

--- a/pkg/plugin/implementation/publisher/publisher.go
+++ b/pkg/plugin/implementation/publisher/publisher.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/rabbitmq/amqp091-go"
 )
 

--- a/pkg/plugin/implementation/reqpreprocessor/cmd/plugin.go
+++ b/pkg/plugin/implementation/reqpreprocessor/cmd/plugin.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/reqpreprocessor"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/reqpreprocessor"
 )
 
 type provider struct{}

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Config represents the configuration for the request preprocessor middleware.

--- a/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
+++ b/pkg/plugin/implementation/reqpreprocessor/reqpreprocessor_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // ToDo Separate Middleware creation and execution.

--- a/pkg/plugin/implementation/router/cmd/plugin.go
+++ b/pkg/plugin/implementation/router/cmd/plugin.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/router"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/router"
 )
 
 // RouterProvider provides instances of Router.

--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/plugin/implementation/router/router_test.go
+++ b/pkg/plugin/implementation/router/router_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 //go:embed testData/*

--- a/pkg/plugin/implementation/schemavalidator/cmd/plugin.go
+++ b/pkg/plugin/implementation/schemavalidator/cmd/plugin.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/schemavalidator"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/schemavalidator"
 )
 
 // schemaValidatorProvider provides instances of schemaValidator.

--- a/pkg/plugin/implementation/schemavalidator/schemavalidator.go
+++ b/pkg/plugin/implementation/schemavalidator/schemavalidator.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )

--- a/pkg/plugin/implementation/signer/cmd/plugin.go
+++ b/pkg/plugin/implementation/signer/cmd/plugin.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/signer"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/signer"
 )
 
 // SignerProvider implements the definition.SignerProvider interface.

--- a/pkg/plugin/implementation/signvalidator/cmd/plugin.go
+++ b/pkg/plugin/implementation/signvalidator/cmd/plugin.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/signvalidator"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/signvalidator"
 )
 
 // provider provides instances of Verifier.

--- a/pkg/plugin/implementation/signvalidator/signvalidator.go
+++ b/pkg/plugin/implementation/signvalidator/signvalidator.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 	"golang.org/x/crypto/blake2b"
 )
 

--- a/pkg/plugin/implementation/simplekeymanager/cmd/plugin.go
+++ b/pkg/plugin/implementation/simplekeymanager/cmd/plugin.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/simplekeymanager"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/simplekeymanager"
 )
 
 // simpleKeyManagerProvider implements the plugin provider for the SimpleKeyManager plugin.

--- a/pkg/plugin/implementation/simplekeymanager/cmd/plugin_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/cmd/plugin_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/simplekeymanager"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/simplekeymanager"
 )
 
 // Mock implementations for testing

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 	"github.com/google/uuid"
 )
 

--- a/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
+++ b/pkg/plugin/implementation/simplekeymanager/simplekeymanager_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // Mock implementations for testing

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
 type onixPlugin interface {

--- a/pkg/plugin/manager_test.go
+++ b/pkg/plugin/manager_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/beckn/beckn-onix/pkg/model"
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
 type mockPlugin struct {

--- a/pkg/plugin/testdata/dummy.go
+++ b/pkg/plugin/testdata/dummy.go
@@ -3,8 +3,8 @@ package main
 import (
 	"context"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
-	"github.com/beckn/beckn-onix/pkg/plugin/implementation/encrypter"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/implementation/encrypter"
 )
 
 // encrypterProvider implements the definition.encrypterProvider interface.

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/beckn/beckn-onix/pkg/log"
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/log"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 // SendAck sends an acknowledgment response (ACK) to the client.

--- a/pkg/response/response_test.go
+++ b/pkg/response/response_test.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/beckn/beckn-onix/pkg/model"
+	"github.com/beckn-one/beckn-onix/pkg/model"
 )
 
 type errorResponseWriter struct{}

--- a/test.go
+++ b/test.go
@@ -6,7 +6,7 @@ import (
 	"plugin"
 	"time"
 
-	"github.com/beckn/beckn-onix/pkg/plugin/definition"
+	"github.com/beckn-one/beckn-onix/pkg/plugin/definition"
 )
 
 func main() {


### PR DESCRIPTION
This PR updates the import statements in the beckn-onix module, switching them from `beckn` to `beckn-one`. Only Go files have been updated.

Issue: https://github.com/Beckn-One/beckn-onix/issues/515