### PR TITLE
feat(router): add excludeAction option for URL routing

### DIFF
--- a/pkg/plugin/implementation/router/router.go
+++ b/pkg/plugin/implementation/router/router.go
@@ -42,6 +42,7 @@ type routingRule struct {
 type target struct {
 	URL         string `yaml:"url,omitempty"`         // URL for "url" or gateway endpoint for "bpp"/"bap"
 	PublisherID string `yaml:"publisherId,omitempty"` // For "msgq" type
+	ExcludeAction bool `yaml:"excludeAction,omitempty"` // For "url" type to exclude appending action to URL path
 }
 
 // TargetType defines possible target destinations.
@@ -115,7 +116,9 @@ func (r *Router) loadRules(configPath string) error {
 				if err != nil {
 					return fmt.Errorf("invalid URL in rule: %w", err)
 				}
-				parsedURL.Path = joinPath(parsedURL, endpoint)
+				if !rule.Target.ExcludeAction {
+					parsedURL.Path = joinPath(parsedURL, endpoint)
+				}
 				route = &model.Route{
 					TargetType: rule.TargetType,
 					URL:        parsedURL,


### PR DESCRIPTION
- Add ExcludeAction field to target struct in routing configuration
- When excludeAction is true, skip appending action to URL path
- Provides flexibility for routing scenarios where action should not be part of URL path
- Maintains backward compatibility by defaulting to existing behaviour
- Allows users to match the exact behaviour of the legacy protocol server which did not append action to the URL when forwarding.

This change allows routing rules to be configured with excludeAction: true when the target URL should not have the action appended to its path.