### PR TITLE
Issue [523] - feat: Add configurable HTTP connection pooling for the adapter service

### DIFF
--- a/config/local-dev.yaml
+++ b/config/local-dev.yaml
@@ -22,6 +22,11 @@ modules:
     handler:
       type: std
       role: bap
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -65,6 +70,11 @@ modules:
     handler:
       type: std
       role: bap
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -104,6 +114,11 @@ modules:
     handler:
       type: std
       role: bpp
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -143,6 +158,11 @@ modules:
     handler:
       type: std
       role: bpp
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry

--- a/config/local-simple.yaml
+++ b/config/local-simple.yaml
@@ -22,6 +22,11 @@ modules:
     handler:
       type: std
       role: bap
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -67,6 +72,11 @@ modules:
     handler:
       type: std
       role: bap
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -108,6 +118,11 @@ modules:
     handler:
       type: std
       role: bpp
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -147,6 +162,11 @@ modules:
     handler:
       type: std
       role: bpp
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry

--- a/config/onix-bap/adapter.yaml
+++ b/config/onix-bap/adapter.yaml
@@ -23,6 +23,11 @@ modules:
     handler:
       type: std
       role: bap
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -68,6 +73,11 @@ modules:
     handler:
       type: std
       role: bap
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry

--- a/config/onix-bpp/adapter.yaml
+++ b/config/onix-bpp/adapter.yaml
@@ -24,6 +24,11 @@ modules:
       type: std
       role: bpp
       subscriberId: bpp1
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -69,6 +74,11 @@ modules:
     handler:
       type: std
       role: bpp
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry

--- a/config/onix/adapter.yaml
+++ b/config/onix/adapter.yaml
@@ -23,6 +23,11 @@ modules:
     handler:
       type: std
       role: bap
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -68,6 +73,11 @@ modules:
     handler:
       type: std
       role: bap
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -114,6 +124,11 @@ modules:
       type: std
       role: bpp
       subscriberId: bpp1
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry
@@ -159,6 +174,11 @@ modules:
     handler:
       type: std
       role: bpp
+      httpClientConfig:
+        maxIdleConns: 1000
+        maxIdleConnsPerHost: 200
+        idleConnTimeout: 300s
+        responseHeaderTimeout: 5s
       plugins:
         registry:
           id: registry

--- a/core/module/handler/config.go
+++ b/core/module/handler/config.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/beckn-one/beckn-onix/pkg/model"
 	"github.com/beckn-one/beckn-onix/pkg/plugin"
@@ -46,12 +47,32 @@ type PluginCfg struct {
 	Steps           []plugin.Config
 }
 
+// HttpClientConfig defines the configuration for the HTTP transport layer.
+type HttpClientConfig struct {
+	// MaxIdleConns controls the maximum number of idle (keep-alive)
+	// connections across all hosts.
+	MaxIdleConns int `yaml:"maxIdleConns"`
+
+	// IdleConnTimeout is the maximum amount of time an idle
+	// (keep-alive) connection will remain idle before closing itself.
+	IdleConnTimeout time.Duration `yaml:"idleConnTimeout"`
+
+	// MaxIdleConnsPerHost, if non-zero, controls the maximum idle
+	// (keep-alive) connections to keep per-host.
+	MaxIdleConnsPerHost int `yaml:"maxIdleConnsPerHost"`
+
+	// ResponseHeaderTimeout, if non-zero, specifies the amount of time to wait
+	// for a server's response headers after fully writing the request.
+	ResponseHeaderTimeout time.Duration `yaml:"responseHeaderTimeout"`
+}
+
 // Config holds the configuration for request processing handlers.
 type Config struct {
-	Plugins      PluginCfg `yaml:"plugins"`
-	Steps        []string
-	Type         Type
-	RegistryURL  string `yaml:"registryUrl"`
-	Role         model.Role
-	SubscriberID string `yaml:"subscriberId"`
+	Plugins          PluginCfg `yaml:"plugins"`
+	Steps            []string
+	Type             Type
+	RegistryURL      string `yaml:"registryUrl"`
+	Role             model.Role
+	SubscriberID     string           `yaml:"subscriberId"`
+	HttpClientConfig HttpClientConfig `yaml:"httpClientConfig"`
 }

--- a/core/module/handler/stdHandler_test.go
+++ b/core/module/handler/stdHandler_test.go
@@ -1,0 +1,153 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPClient(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   HttpClientConfig
+		expected struct {
+			maxIdleConns          int
+			maxIdleConnsPerHost   int
+			idleConnTimeout       time.Duration
+			responseHeaderTimeout time.Duration
+		}
+	}{
+		{
+			name: "all values configured",
+			config: HttpClientConfig{
+				MaxIdleConns:          1000,
+				MaxIdleConnsPerHost:   200,
+				IdleConnTimeout:       300 * time.Second,
+				ResponseHeaderTimeout: 5 * time.Second,
+			},
+			expected: struct {
+				maxIdleConns          int
+				maxIdleConnsPerHost   int
+				idleConnTimeout       time.Duration
+				responseHeaderTimeout time.Duration
+			}{
+				maxIdleConns:          1000,
+				maxIdleConnsPerHost:   200,
+				idleConnTimeout:       300 * time.Second,
+				responseHeaderTimeout: 5 * time.Second,
+			},
+		},
+		{
+			name:   "zero values use defaults",
+			config: HttpClientConfig{},
+			expected: struct {
+				maxIdleConns          int
+				maxIdleConnsPerHost   int
+				idleConnTimeout       time.Duration
+				responseHeaderTimeout time.Duration
+			}{
+				maxIdleConns:          100, // Go default
+				maxIdleConnsPerHost:   0,   // Go default (unlimited per host)
+				idleConnTimeout:       90 * time.Second,
+				responseHeaderTimeout: 0,
+			},
+		},
+		{
+			name: "partial configuration",
+			config: HttpClientConfig{
+				MaxIdleConns:        500,
+				IdleConnTimeout:     180 * time.Second,
+			},
+			expected: struct {
+				maxIdleConns          int
+				maxIdleConnsPerHost   int
+				idleConnTimeout       time.Duration
+				responseHeaderTimeout time.Duration
+			}{
+				maxIdleConns:          500,
+				maxIdleConnsPerHost:   0, // Go default (unlimited per host)
+				idleConnTimeout:       180 * time.Second,
+				responseHeaderTimeout: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newHTTPClient(&tt.config)
+			
+			if client == nil {
+				t.Fatal("newHTTPClient returned nil")
+			}
+
+			transport, ok := client.Transport.(*http.Transport)
+			if !ok {
+				t.Fatal("client transport is not *http.Transport")
+			}
+
+			if transport.MaxIdleConns != tt.expected.maxIdleConns {
+				t.Errorf("MaxIdleConns = %d, want %d", transport.MaxIdleConns, tt.expected.maxIdleConns)
+			}
+
+			if transport.MaxIdleConnsPerHost != tt.expected.maxIdleConnsPerHost {
+				t.Errorf("MaxIdleConnsPerHost = %d, want %d", transport.MaxIdleConnsPerHost, tt.expected.maxIdleConnsPerHost)
+			}
+
+			if transport.IdleConnTimeout != tt.expected.idleConnTimeout {
+				t.Errorf("IdleConnTimeout = %v, want %v", transport.IdleConnTimeout, tt.expected.idleConnTimeout)
+			}
+
+			if transport.ResponseHeaderTimeout != tt.expected.responseHeaderTimeout {
+				t.Errorf("ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, tt.expected.responseHeaderTimeout)
+			}
+		})
+	}
+}
+
+func TestHttpClientConfigDefaults(t *testing.T) {
+	// Test that zero config values don't override defaults
+	config := &HttpClientConfig{}
+	client := newHTTPClient(config)
+	
+	transport := client.Transport.(*http.Transport)
+	
+	// Verify defaults are preserved when config values are zero
+	if transport.MaxIdleConns == 0 {
+		t.Error("MaxIdleConns should not be zero when using defaults")
+	}
+	
+	// MaxIdleConnsPerHost default is 0 (unlimited), which is correct
+	if transport.MaxIdleConns != 100 {
+		t.Errorf("Expected default MaxIdleConns=100, got %d", transport.MaxIdleConns)
+	}
+}
+
+func TestHttpClientConfigPerformanceValues(t *testing.T) {
+	// Test the specific performance-optimized values from the document
+	config := &HttpClientConfig{
+		MaxIdleConns:          1000,
+		MaxIdleConnsPerHost:   200,
+		IdleConnTimeout:       300 * time.Second,
+		ResponseHeaderTimeout: 5 * time.Second,
+	}
+	
+	client := newHTTPClient(config)
+	transport := client.Transport.(*http.Transport)
+	
+	// Verify performance-optimized values
+	if transport.MaxIdleConns != 1000 {
+		t.Errorf("Expected MaxIdleConns=1000, got %d", transport.MaxIdleConns)
+	}
+	
+	if transport.MaxIdleConnsPerHost != 200 {
+		t.Errorf("Expected MaxIdleConnsPerHost=200, got %d", transport.MaxIdleConnsPerHost)
+	}
+	
+	if transport.IdleConnTimeout != 300*time.Second {
+		t.Errorf("Expected IdleConnTimeout=300s, got %v", transport.IdleConnTimeout)
+	}
+	
+	if transport.ResponseHeaderTimeout != 5*time.Second {
+		t.Errorf("Expected ResponseHeaderTimeout=5s, got %v", transport.ResponseHeaderTimeout)
+	}
+}


### PR DESCRIPTION


  Under high-load scenarios, the default Go http.Client settings in the adapter service act as a significant performance bottleneck. This leads to high latency,
  potential port exhaustion, and increased CPU usage due to the constant creation of new TCP/TLS connections for outgoing requests.

  This PR introduces a configurable http.Transport to enable connection reuse (HTTP keep-alive) and create a much larger connection pool, significantly improving
  performance and stability under load.

Changes Implemented:

   1. `core/module/handler/config.go`:
       * Introduced a new HttpClientConfig struct to hold transport settings (maxIdleConns, maxIdleConnsPerHost, idleConnTimeout, responseHeaderTimeout).
       * Added HttpClientConfig to the main handler Config struct.

   2. `core/module/handler/stdHandler.go`:
       * Added a newHTTPClient function that creates a custom http.Client with a configured http.Transport based on the new settings.
       * The stdHandler now uses this custom client for all outgoing reverse proxy requests, ensuring the connection pool is utilized.

   3. Updated the adapter module configurations to include the new httpClientConfig block with performance-tuned values.

Configuration:
  ```httpClientConfig:
      maxIdleConns: 1000
      maxIdleConnsPerHost: 200
      idleConnTimeout: 300s
      responseHeaderTimeout: 5s
```

Issue : https://github.com/Beckn-One/beckn-onix/issues/523