### PR TITLE
Issue [ 526 ] -  Implement automatic key synchronization for ONIX adapter deployment and build plugin steps.

### DIFF
--- a/config/local-simple.yaml
+++ b/config/local-simple.yaml
@@ -64,6 +64,7 @@ modules:
               uuidKeys: transaction_id,message_id
               role: bap
       steps:
+        - validateSign
         - addRoute
         - validateSchema
   

--- a/config/local-simple.yaml
+++ b/config/local-simple.yaml
@@ -155,6 +155,7 @@ modules:
           config:
             routingConfig: ./config/local-simple-routing-BPPReceiver.yaml
       steps:
+        - validateSign
         - addRoute
   
   - name: bppTxnCaller


### PR DESCRIPTION
Added `configure_onix_registry_keys()` function that:
- Extracts keys from protocol server YAML configs automatically
- Converts 64-byte private keys to 32-byte format for ONIX compatibility  
- Auto-detects ONIX config files from docker-compose settings
- Updates keyManager sections with proper YAML formatting
- Validates module compatibility for BAP/BPP/combined deployments
- Enhanced `beckn-onix.sh` with automatic key synchronization

Added build plugins step to beckn-onix.sh

Issue : https://github.com/Beckn-One/beckn-onix/issues/526